### PR TITLE
Fix arithmetic error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ while (i < 10) {
 num j = 10;
 do {
     j = j - 1;
-} until (j == 10)
+} until (j == 0)
 
 for (num i = 0; i < 10; i = i + 1) {
     | ...


### PR DESCRIPTION
Because `j == 10` at initialization and we are decrementing in the example, we'll want to check for `j == 0`.