### PR TITLE
feat(list/map): Added `list.clone` and `map.clone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@
 - New integer literal for single chars: `'A' == 65`
 - Compiler will warn you when a local or global is never used or when an expression value is discarded. To silence those warnings you can use the `_ = <expression>` or name the local/global `_`.
 - `std.currentFiber`, `fiber.isMain`
-- `map.sort`, `map.forEach`, `map.map`, `map.filter`, `map.reduce`, `map.diff`, `map.intersect`
+- `map.sort`, `map.forEach`, `map.map`, `map.filter`, `map.reduce`, `map.diff`, `map.intersect`, `map.clone`
+- `list.clone`
 - Number literals can embed `_`: `1_000_000.300_245`
 
 ## Changed

--- a/src/builtin/list.zig
+++ b/src/builtin/list.zig
@@ -136,8 +136,8 @@ pub fn sort(ctx: *NativeCtx) c_int {
 }
 
 pub fn indexOf(ctx: *NativeCtx) c_int {
-    var self: *ObjList = ObjList.cast(ctx.vm.peek(1).obj()).?;
-    var needle: Value = ctx.vm.peek(0);
+    const self: *ObjList = ObjList.cast(ctx.vm.peek(1).obj()).?;
+    const needle: Value = ctx.vm.peek(0);
 
     var index: ?usize = null;
     var i: usize = 0;
@@ -151,6 +151,20 @@ pub fn indexOf(ctx: *NativeCtx) c_int {
     }
 
     ctx.vm.push(if (index) |uindex| Value.fromInteger(@as(i32, @intCast(uindex))) else Value.Null);
+
+    return 1;
+}
+
+pub fn clone(ctx: *NativeCtx) c_int {
+    const self: *ObjList = ObjList.cast(ctx.vm.peek(0).obj()).?;
+
+    var new_list = ctx.vm.gc.allocateObject(
+        ObjList,
+        ObjList.init(ctx.vm.gc.allocator, self.type_def),
+    ) catch @panic("Out of memory");
+    new_list.items.appendSlice(self.items.items) catch @panic("Out of memory");
+
+    ctx.vm.push(new_list.toValue());
 
     return 1;
 }

--- a/src/builtin/map.zig
+++ b/src/builtin/map.zig
@@ -15,6 +15,21 @@ const floatToInteger = _value.floatToInteger;
 const valueEql = _value.valueEql;
 const valueToString = _value.valueToString;
 
+pub fn clone(ctx: *NativeCtx) c_int {
+    const self = ObjMap.cast(ctx.vm.peek(0).obj()).?;
+
+    var new_map = ctx.vm.gc.allocateObject(
+        ObjMap,
+        ObjMap.init(ctx.vm.gc.allocator, self.type_def),
+    ) catch @panic("Out of memory");
+    new_map.map.deinit();
+    new_map.map = self.map.clone() catch @panic("Out of memory");
+
+    ctx.vm.push(new_map.toValue());
+
+    return 1;
+}
+
 pub fn reduce(ctx: *NativeCtx) c_int {
     const self = ObjMap.cast(ctx.vm.peek(2).obj()).?;
     const closure = ObjClosure.cast(ctx.vm.peek(1).obj()).?;

--- a/src/obj.zig
+++ b/src/obj.zig
@@ -1534,19 +1534,20 @@ pub const ObjList = struct {
         NativeFn,
         .{
             .{ "append", buzz_builtin.list.append },
-            .{ "remove", buzz_builtin.list.remove },
-            .{ "len", buzz_builtin.list.len },
-            .{ "next", buzz_builtin.list.next },
-            .{ "sub", buzz_builtin.list.sub },
-            .{ "indexOf", buzz_builtin.list.indexOf },
-            .{ "join", buzz_builtin.list.join },
-            .{ "insert", buzz_builtin.list.insert },
-            .{ "pop", buzz_builtin.list.pop },
-            .{ "forEach", buzz_builtin.list.forEach },
-            .{ "map", buzz_builtin.list.map },
+            .{ "clone", buzz_builtin.list.clone },
             .{ "filter", buzz_builtin.list.filter },
+            .{ "forEach", buzz_builtin.list.forEach },
+            .{ "indexOf", buzz_builtin.list.indexOf },
+            .{ "insert", buzz_builtin.list.insert },
+            .{ "join", buzz_builtin.list.join },
+            .{ "len", buzz_builtin.list.len },
+            .{ "map", buzz_builtin.list.map },
+            .{ "next", buzz_builtin.list.next },
+            .{ "pop", buzz_builtin.list.pop },
             .{ "reduce", buzz_builtin.list.reduce },
+            .{ "remove", buzz_builtin.list.remove },
             .{ "sort", buzz_builtin.list.sort },
+            .{ "sub", buzz_builtin.list.sub },
         },
     );
 
@@ -2327,6 +2328,34 @@ pub const ObjList = struct {
                 try self.methods.put("sort", native_type);
 
                 return native_type;
+            } else if (mem.eql(u8, method, "clone")) {
+                // We omit first arg: it'll be OP_SWAPed in and we already parsed it
+                // It's always the list.
+
+                var method_def = ObjFunction.FunctionDef{
+                    .id = ObjFunction.FunctionDef.nextId(),
+                    .script_name = try parser.gc.copyString("builtin"),
+                    .name = try parser.gc.copyString("clone"),
+                    .parameters = std.AutoArrayHashMap(*ObjString, *ObjTypeDef).init(parser.gc.allocator),
+                    .defaults = std.AutoArrayHashMap(*ObjString, Value).init(parser.gc.allocator),
+                    .return_type = obj_list,
+                    .yield_type = try parser.gc.type_registry.getTypeDef(.{ .def_type = .Void }),
+                    .generic_types = std.AutoArrayHashMap(*ObjString, *ObjTypeDef).init(parser.gc.allocator),
+                    .function_type = .Extern,
+                };
+
+                var resolved_type: ObjTypeDef.TypeUnion = .{ .Function = method_def };
+
+                var native_type = try parser.gc.type_registry.getTypeDef(
+                    ObjTypeDef{
+                        .def_type = .Function,
+                        .resolved_type = resolved_type,
+                    },
+                );
+
+                try self.methods.put("clone", native_type);
+
+                return native_type;
             }
 
             return null;
@@ -2363,17 +2392,18 @@ pub const ObjMap = struct {
     const members = std.ComptimeStringMap(
         NativeFn,
         .{
+            .{ "clone", buzz_builtin.map.clone },
+            .{ "diff", buzz_builtin.map.diff },
+            .{ "filter", buzz_builtin.map.filter },
+            .{ "forEach", buzz_builtin.map.forEach },
+            .{ "intersect", buzz_builtin.map.intersect },
+            .{ "keys", buzz_builtin.map.keys },
+            .{ "map", buzz_builtin.map.map },
+            .{ "reduce", buzz_builtin.map.reduce },
             .{ "remove", buzz_builtin.map.remove },
             .{ "size", buzz_builtin.map.size },
-            .{ "keys", buzz_builtin.map.keys },
-            .{ "values", buzz_builtin.map.values },
             .{ "sort", buzz_builtin.map.sort },
-            .{ "forEach", buzz_builtin.map.forEach },
-            .{ "map", buzz_builtin.map.map },
-            .{ "filter", buzz_builtin.map.filter },
-            .{ "reduce", buzz_builtin.map.reduce },
-            .{ "diff", buzz_builtin.map.diff },
-            .{ "intersect", buzz_builtin.map.intersect },
+            .{ "values", buzz_builtin.map.values },
         },
     );
 
@@ -3105,6 +3135,34 @@ pub const ObjMap = struct {
                 );
 
                 try self.methods.put("reduce", native_type);
+
+                return native_type;
+            } else if (mem.eql(u8, method, "clone")) {
+                // We omit first arg: it'll be OP_SWAPed in and we already parsed it
+                // It's always the list.
+
+                var method_def = ObjFunction.FunctionDef{
+                    .id = ObjFunction.FunctionDef.nextId(),
+                    .script_name = try parser.gc.copyString("builtin"),
+                    .name = try parser.gc.copyString("clone"),
+                    .parameters = std.AutoArrayHashMap(*ObjString, *ObjTypeDef).init(parser.gc.allocator),
+                    .defaults = std.AutoArrayHashMap(*ObjString, Value).init(parser.gc.allocator),
+                    .return_type = obj_map,
+                    .yield_type = try parser.gc.type_registry.getTypeDef(.{ .def_type = .Void }),
+                    .generic_types = std.AutoArrayHashMap(*ObjString, *ObjTypeDef).init(parser.gc.allocator),
+                    .function_type = .Extern,
+                };
+
+                var resolved_type: ObjTypeDef.TypeUnion = .{ .Function = method_def };
+
+                var native_type = try parser.gc.type_registry.getTypeDef(
+                    ObjTypeDef{
+                        .def_type = .Function,
+                        .resolved_type = resolved_type,
+                    },
+                );
+
+                try self.methods.put("clone", native_type);
 
                 return native_type;
             }

--- a/tests/004-lists.buzz
+++ b/tests/004-lists.buzz
@@ -48,3 +48,13 @@ test "list.join" {
 test "list concat" {
     assert(([1, 2, 3] + [4, 5, 6]).join(",") == "1,2,3,4,5,6", message: "list concat");
 }
+
+test "list.clone" {
+    [int] list = [1, 2, 3];
+    [int] copy = list.clone();
+
+    assert(list.len() == copy.len(), message: "Could clone list");
+    foreach (int i, int el in copy) {
+        assert(list[i] == el, message: "Could clone list");
+    }
+}

--- a/tests/005-maps.buzz
+++ b/tests/005-maps.buzz
@@ -70,3 +70,17 @@ test "map.intersect" {
 
     assert(intersect.size() == 1 and intersect["two"] != null, message: "Could use map.intersect");
 }
+
+test "map.clone" {
+    {str, int} first = {
+        "one": 1,
+        "two": 2,
+        "five": 5,
+    };
+    {str, int} copy = first.clone();
+
+    assert(copy.size() == first.size(), message: "Could clone map");
+    foreach (str key, int value in copy) {
+        assert(first[key] == value, message: "Could clone map");
+    }
+}


### PR DESCRIPTION
closes #112

If user has to iterate and mutate list/map at the same time, it can use those functions:
```buzz
[int] values = [1, 2, 3];

foreach (int i, int value in values.clone()) {
    if (value % 2 == 0) {
        values.remove(i);
    }
}
```