### PR TITLE
fix: update build script and http start function for latest zig version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -92,7 +92,7 @@ fn get_buzz_prefix(b: *Build) []const u8 {
 pub fn build(b: *Build) !void {
     // Check minimum zig version
     const current_zig = builtin.zig_version;
-    const min_zig = std.SemanticVersion.parse("0.12.0-dev.411+ada02ac6f") catch return;
+    const min_zig = std.SemanticVersion.parse("0.12.0-dev.668+c07d6e4c1") catch return;
     if (current_zig.order(min_zig).compare(.lt)) {
         @panic(b.fmt("Your Zig version v{} does not meet the minimum build requirement of v{}", .{ current_zig, min_zig }));
     }

--- a/src/lib/buzz_http.zig
+++ b/src/lib/buzz_http.zig
@@ -93,7 +93,9 @@ export fn HttpClientSend(ctx: *api.NativeCtx) c_int {
         return -1;
     };
 
-    request.start() catch |err| {
+    const options = http.Client.Request.StartOptions{ .raw_uri = false };
+
+    request.start(options) catch |err| {
         handleStartError(ctx, err);
 
         return -1;


### PR DESCRIPTION
This fixes the languages from being able to built using zig(0.12.0-dev.668+c07d6e4c1).