### PR TITLE
Sandboxing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 - REPL (https://github.com/buzz-language/buzz/issues/17) available by running buzz without any argument
 - Function argument names and object property names can be ommitted if the provided value is a named variable with the same name (https://github.com/buzz-language/buzz/issues/204)
+- Sandboxing build options `memory_limit` and `cycle_limit` (https://github.com/buzz-language/buzz/issues/182)
 
 ## Changed
 - Map type notation has changed from `{K, V}` to `{K: V}`. Similarly map expression with specified typed went from `{<K, V>, ...}` to `{<K: V>, ...}` (https://github.com/buzz-language/buzz/issues/253)

--- a/build.zig
+++ b/build.zig
@@ -42,6 +42,7 @@ const BuzzGCOptions = struct {
     initial_gc: usize,
     next_gc_ratio: usize,
     next_full_gc_ratio: usize,
+    memory_limit: ?usize,
 
     pub fn step(self: BuzzGCOptions, options: *Build.Step.Options) void {
         options.addOption(@TypeOf(self.debug), "gc_debug", self.debug);
@@ -51,6 +52,7 @@ const BuzzGCOptions = struct {
         options.addOption(@TypeOf(self.initial_gc), "initial_gc", self.initial_gc);
         options.addOption(@TypeOf(self.next_gc_ratio), "next_gc_ratio", self.next_gc_ratio);
         options.addOption(@TypeOf(self.next_full_gc_ratio), "next_full_gc_ratio", self.next_full_gc_ratio);
+        options.addOption(@TypeOf(self.memory_limit), "memory_limit", self.memory_limit);
     }
 };
 
@@ -211,6 +213,11 @@ pub fn build(b: *Build) !void {
                 "next_full_gc_ratio",
                 "Ratio applied to get the next full GC threshold",
             ) orelse 4,
+            .memory_limit = b.option(
+                usize,
+                "memory_limit",
+                "Memory limit",
+            ) orelse null,
         },
         .jit = .{
             .debug = b.option(

--- a/src/Codegen.zig
+++ b/src/Codegen.zig
@@ -21,6 +21,7 @@ pub const Error = error{
     CantCompile,
     UnwrappedNull,
     OutOfBound,
+    ReachedMaximumMemoryUsage,
 } || std.mem.Allocator.Error || std.fmt.BufPrintError;
 
 pub const Frame = struct {

--- a/src/Jit.zig
+++ b/src/Jit.zig
@@ -11,7 +11,12 @@ const ZigType = @import("zigtypes.zig").Type;
 const ExternApi = @import("jit_extern_api.zig").ExternApi;
 const api = @import("lib/buzz_api.zig");
 
-pub const Error = error{ CantCompile, UnwrappedNull, OutOfBound } || std.mem.Allocator.Error || std.fmt.BufPrintError;
+pub const Error = error{
+    CantCompile,
+    UnwrappedNull,
+    OutOfBound,
+    ReachedMaximumMemoryUsage,
+} || std.mem.Allocator.Error || std.fmt.BufPrintError;
 
 const OptJump = struct {
     current_insn: std.ArrayList(m.MIR_insn_t),

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -193,6 +193,7 @@ pub const Error = error{
     CantCompile,
     UnwrappedNull,
     OutOfBound,
+    ReachedMaximumMemoryUsage,
 } || std.mem.Allocator.Error || std.fmt.BufPrintError || CompileError;
 
 const ParseFn = *const fn (*Self, bool) Error!Ast.Node.Index;
@@ -708,6 +709,10 @@ pub fn parse(self: *Self, source: []const u8, file_name: []const u8) !?Ast {
             }
         } else {
             if (self.declaration() catch |err| {
+                if (err == error.ReachedMaximumMemoryUsage) {
+                    return err;
+                }
+
                 if (BuildOptions.debug) {
                     std.debug.print("Parsing failed with error {}\n", .{err});
                 }

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7081,7 +7081,7 @@ fn importStatement(self: *Self) Error!Ast.Node.Index {
 }
 
 fn zdefStatement(self: *Self) Error!Ast.Node.Index {
-    if (!BuildOptions.jit) {
+    if (!BuildOptions.jit and BuildOptions.cycle_limit == null) {
         self.reportError(.zdef, "zdef can't be used, this instance of buzz was built with JIT compiler disabled");
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -30,7 +30,7 @@ fn runFile(allocator: Allocator, file_name: []const u8, args: [][:0]u8, flavor: 
     };
     var imports = std.StringHashMap(Parser.ScriptImport).init(allocator);
     var vm = try VM.init(&gc, &import_registry, flavor);
-    vm.jit = if (BuildOptions.jit)
+    vm.jit = if (BuildOptions.jit and BuildOptions.cycle_limit == null)
         JIT.init(&vm)
     else
         null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -264,9 +264,10 @@ pub fn main() !void {
 
     if (flavor == .Repl) {
         repl(allocator) catch |err| {
-            if (BuildOptions.debug) {
-                std.debug.print("Failed with error {}\n", .{err});
-            }
+            std.io.getStdErr().writer().print(
+                "Failed with error {s}\n",
+                .{@errorName(err)},
+            ) catch unreachable;
 
             std.os.exit(1);
         };
@@ -277,9 +278,10 @@ pub fn main() !void {
             positionals.items[1..],
             flavor,
         ) catch |err| {
-            if (BuildOptions.debug) {
-                std.debug.print("Failed with error {}\n", .{err});
-            }
+            std.io.getStdErr().writer().print(
+                "Failed with error {s}\n",
+                .{@errorName(err)},
+            ) catch unreachable;
 
             std.os.exit(1);
         };

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -215,6 +215,10 @@ pub const GarbageCollector = struct {
             try self.collectGarbage();
         }
 
+        if (BuildOptions.memory_limit != null and self.bytes_allocated > BuildOptions.memory_limit.?) {
+            return error.ReachedMaximumMemoryUsage;
+        }
+
         const allocated = try self.allocator.create(T);
 
         if (BuildOptions.gc_debug) {

--- a/src/obj.zig
+++ b/src/obj.zig
@@ -297,7 +297,7 @@ pub const Obj = struct {
         }
     }
 
-    pub fn typeOf(self: *Self, gc: *GarbageCollector) error{ OutOfMemory, NoSpaceLeft }!*ObjTypeDef {
+    pub fn typeOf(self: *Self, gc: *GarbageCollector) error{ OutOfMemory, NoSpaceLeft, ReachedMaximumMemoryUsage }!*ObjTypeDef {
         return switch (self.obj_type) {
             .String => try gc.type_registry.getTypeDef(.{ .def_type = .String }),
             .Pattern => try gc.type_registry.getTypeDef(.{ .def_type = .Pattern }),

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -329,6 +329,7 @@ pub const VM = struct {
         NotInFiber,
         FiberOver,
         BadNumber,
+        ReachedMaximumMemoryUsage,
         Custom, // TODO: remove when user can use this set directly in buzz code
     } || Allocator.Error || std.fmt.BufPrintError;
 

--- a/tests/bench/001-btree.buzz
+++ b/tests/bench/001-btree.buzz
@@ -57,7 +57,7 @@ fun btree(int N) > void {
 }
 
 fun main([str] args) > void !> any {
-    int N = if (args.len() > 0) parseInt(args[0]) ?? 0 else 0;
+    int N = if (args.len() > 0) parseInt(args[0]) ?? 3 else 3;
 
     btree(N);
 }


### PR DESCRIPTION
Two new build flags:

- `-Dmemory_limit` to give a memory usage limit.
- `-Dcycle_limit` to give a VM cycles limit. This disables the JIT compiler until I figure out how to evaluate the amount of cpu usage of a compiled function.
- Further sandboxing would require forbidding usage of standard libs like `io`, `fs` etc. Which is already possible by having a copy of buzz without those libs `.dylib`/`.so` files