### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A small/lightweight statically typed scripting language written in Zig
 - Statically typed
 - Unambiguous
 - No nonsense coercion
-- [Fibers](#fibers)
+- [Fibers](https://buzz-lang.dev/guide/fibers.html)
 - JIT compilation with [MIR](https://github.com/vnmakarov/mir)
 - Tooling
     - Generate doc from docblocks (planned)


### PR DESCRIPTION
In https://github.com/buzz-language/buzz/commit/cf893026cf8167410f4575a5f2623739cd0027b1 the reference to fibers got removed from the readme, but the link didn't get updated.