### PR TITLE
feat: Integers are i48

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ dist/
 *.so
 *.o
 
-tests/utils/*foreign.*
+tests/utils/libforeign.*
 buzz_history
 
 node_modules

--- a/src/Ast.zig
+++ b/src/Ast.zig
@@ -484,10 +484,10 @@ pub const Slice = struct {
 
         const left = try self.toValue(components.left, gc);
         const left_integer = if (left.isInteger()) left.integer() else null;
-        const left_float = if (left.isFloat()) left.double() else null;
+        const left_float = if (left.isDouble()) left.double() else null;
         const right = try self.toValue(components.right, gc);
         const right_integer = if (right.isInteger()) right.integer() else null;
-        const right_float = if (right.isFloat()) right.double() else null;
+        const right_float = if (right.isDouble()) right.double() else null;
 
         switch (components.operator) {
             .Ampersand => return Value.fromInteger(left_integer.? & right_integer.?),
@@ -544,11 +544,11 @@ pub const Slice = struct {
                     if (right_float) |rf| {
                         return Value.fromBoolean(lf > rf);
                     } else {
-                        return Value.fromBoolean(lf > @as(f64, @floatFromInt(right_integer.?)));
+                        return Value.fromBoolean(lf > @as(v.Double, @floatFromInt(right_integer.?)));
                     }
                 } else {
                     if (right_float) |rf| {
-                        return Value.fromBoolean(@as(f64, @floatFromInt(left_integer.?)) > rf);
+                        return Value.fromBoolean(@as(v.Double, @floatFromInt(left_integer.?)) > rf);
                     } else {
                         return Value.fromBoolean(left_integer.? > right_integer.?);
                     }
@@ -561,11 +561,11 @@ pub const Slice = struct {
                     if (right_float) |rf| {
                         return Value.fromBoolean(lf < rf);
                     } else {
-                        return Value.fromBoolean(lf < @as(f64, @floatFromInt(right_integer.?)));
+                        return Value.fromBoolean(lf < @as(v.Double, @floatFromInt(right_integer.?)));
                     }
                 } else {
                     if (right_float) |rf| {
-                        return Value.fromBoolean(@as(f64, @floatFromInt(left_integer.?)) < rf);
+                        return Value.fromBoolean(@as(v.Double, @floatFromInt(left_integer.?)) < rf);
                     } else {
                         return Value.fromBoolean(left_integer.? < right_integer.?);
                     }
@@ -578,11 +578,11 @@ pub const Slice = struct {
                     if (right_float) |rf| {
                         return Value.fromBoolean(lf >= rf);
                     } else {
-                        return Value.fromBoolean(lf >= @as(f64, @floatFromInt(right_integer.?)));
+                        return Value.fromBoolean(lf >= @as(v.Double, @floatFromInt(right_integer.?)));
                     }
                 } else {
                     if (right_float) |rf| {
-                        return Value.fromBoolean(@as(f64, @floatFromInt(left_integer.?)) >= rf);
+                        return Value.fromBoolean(@as(v.Double, @floatFromInt(left_integer.?)) >= rf);
                     } else {
                         return Value.fromBoolean(left_integer.? >= right_integer.?);
                     }
@@ -595,11 +595,11 @@ pub const Slice = struct {
                     if (right_float) |rf| {
                         return Value.fromBoolean(lf <= rf);
                     } else {
-                        return Value.fromBoolean(lf <= @as(f64, @floatFromInt(right_integer.?)));
+                        return Value.fromBoolean(lf <= @as(v.Double, @floatFromInt(right_integer.?)));
                     }
                 } else {
                     if (right_float) |rf| {
-                        return Value.fromBoolean(@as(f64, @floatFromInt(left_integer.?)) <= rf);
+                        return Value.fromBoolean(@as(v.Double, @floatFromInt(left_integer.?)) <= rf);
                     } else {
                         return Value.fromBoolean(left_integer.? <= right_integer.?);
                     }
@@ -626,7 +626,7 @@ pub const Slice = struct {
 
                     return (try gc.copyString(try new_string.toOwnedSlice())).toValue();
                 } else if (right_float) |rf| {
-                    return Value.fromFloat(rf + left_float.?);
+                    return Value.fromDouble(rf + left_float.?);
                 } else if (right_integer) |ri| {
                     return Value.fromInteger(ri +% left_integer.?);
                 } else if (right_list) |rl| {
@@ -665,28 +665,28 @@ pub const Slice = struct {
             },
             .Minus => {
                 if (right_float) |rf| {
-                    return Value.fromFloat(rf - left_float.?);
+                    return Value.fromDouble(rf - left_float.?);
                 }
 
                 return Value.fromInteger(right_integer.? -% left_integer.?);
             },
             .Star => {
                 if (right_float) |rf| {
-                    return Value.fromFloat(rf * left_float.?);
+                    return Value.fromDouble(rf * left_float.?);
                 }
 
                 return Value.fromInteger(right_integer.? *% left_integer.?);
             },
             .Slash => {
                 if (right_float) |rf| {
-                    return Value.fromFloat(left_float.? / rf);
+                    return Value.fromDouble(left_float.? / rf);
                 }
 
                 return Value.fromInteger(@divTrunc(left_integer.?, right_integer.?));
             },
             .Percent => {
                 if (right_float) |rf| {
-                    return Value.fromFloat(@mod(left_float.?, rf));
+                    return Value.fromDouble(@mod(left_float.?, rf));
                 }
 
                 return Value.fromInteger(@mod(left_integer.?, right_integer.?));
@@ -721,7 +721,7 @@ pub const Slice = struct {
                 .Pattern => self.nodes.items(.components)[node].Pattern.toValue(),
                 .Void => Value.Void,
                 .Null => Value.Null,
-                .Double => Value.fromFloat(self.nodes.items(.components)[node].Double),
+                .Double => Value.fromDouble(self.nodes.items(.components)[node].Double),
                 .Integer => Value.fromInteger(self.nodes.items(.components)[node].Integer),
                 .Boolean => Value.fromBoolean(self.nodes.items(.components)[node].Boolean),
                 .As => try self.toValue(self.nodes.items(.components)[node].As.left, gc),
@@ -885,7 +885,7 @@ pub const Slice = struct {
                         .Minus => if (val.isInteger())
                             Value.fromInteger(-%val.integer())
                         else
-                            Value.fromFloat(-val.double()),
+                            Value.fromDouble(-val.double()),
                         else => unreachable,
                     };
                 },

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -5,7 +5,9 @@ const BuildOptions = @import("build_options");
 const obj = @import("obj.zig");
 const Token = @import("Token.zig");
 const Chunk = @import("Chunk.zig");
-const Value = @import("value.zig").Value;
+const v = @import("value.zig");
+const Value = v.Value;
+const Integer = v.Integer;
 const FFI = @import("FFI.zig");
 const Ast = @import("Ast.zig");
 const GarbageCollector = @import("memory.zig").GarbageCollector;
@@ -7912,7 +7914,7 @@ fn enumDeclaration(self: *Self) Error!Ast.Node.Index {
     var cases = std.ArrayList(Ast.Enum.Case).init(self.gc.allocator);
     var def_cases = std.ArrayList([]const u8).init(self.gc.allocator);
     var picked = std.ArrayList(bool).init(self.gc.allocator);
-    var case_index: i32 = 0;
+    var case_index: v.Integer = 0;
     while (!self.check(.RightBrace) and !self.check(.Eof)) : (case_index += 1) {
         if (case_index > std.math.maxInt(u24)) {
             const location = self.ast.tokens.get(self.current_token.? - 1);

--- a/src/Scanner.zig
+++ b/src/Scanner.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const mem = std.mem;
 const Allocator = mem.Allocator;
 const Token = @import("Token.zig");
+const v = @import("value.zig");
 
 pub const SourceLocation = struct {
     start: usize,
@@ -342,7 +343,7 @@ fn number(self: *Self) Token {
     }
 
     const double = if (is_float)
-        std.fmt.parseFloat(f64, self.source[self.current.start..self.current.offset]) catch {
+        std.fmt.parseFloat(v.Double, self.source[self.current.start..self.current.offset]) catch {
             return self.makeToken(
                 .Error,
                 "double overflow",
@@ -354,7 +355,7 @@ fn number(self: *Self) Token {
         null;
 
     const int = if (!is_float)
-        std.fmt.parseInt(i32, self.source[self.current.start..self.current.offset], 10) catch {
+        std.fmt.parseInt(v.Integer, self.source[self.current.start..self.current.offset], 10) catch {
             return self.makeToken(
                 .Error,
                 "int overflow",
@@ -429,7 +430,7 @@ fn binary(self: *Self) Token {
         .IntegerValue,
         null,
         null,
-        std.fmt.parseInt(i32, self.source[self.current.start + 2 .. self.current.offset], 2) catch {
+        std.fmt.parseInt(v.Integer, self.source[self.current.start + 2 .. self.current.offset], 2) catch {
             return self.makeToken(
                 .Error,
                 "int overflow",
@@ -461,7 +462,7 @@ fn hexa(self: *Self) Token {
         .IntegerValue,
         null,
         null,
-        std.fmt.parseInt(i32, self.source[self.current.start + 2 .. self.current.offset], 16) catch {
+        std.fmt.parseInt(v.Integer, self.source[self.current.start + 2 .. self.current.offset], 16) catch {
             return self.makeToken(
                 .Error,
                 "int overflow",
@@ -611,7 +612,7 @@ fn match(self: *Self, expected: u8) bool {
     return true;
 }
 
-fn makeToken(self: *Self, tag: Token.Type, literal_string: ?[]const u8, literal_float: ?f64, literal_integer: ?i32) Token {
+fn makeToken(self: *Self, tag: Token.Type, literal_string: ?[]const u8, literal_float: ?v.Double, literal_integer: ?v.Integer) Token {
     self.token_index += 1;
     return Token{
         .tag = tag,

--- a/src/Token.zig
+++ b/src/Token.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const mem = std.mem;
+const v = @import("value.zig");
 
 const Self = @This();
 
@@ -10,8 +11,8 @@ tag: Type,
 lexeme: []const u8,
 // Literal is either a string or a number
 literal_string: ?[]const u8 = null,
-literal_float: ?f64 = null,
-literal_integer: ?i32 = null,
+literal_float: ?v.Double = null,
+literal_integer: ?v.Integer = null,
 line: usize,
 column: usize,
 offset: usize = 0,

--- a/src/builtin/fiber.zig
+++ b/src/builtin/fiber.zig
@@ -1,21 +1,18 @@
 const std = @import("std");
-const _obj = @import("../obj.zig");
-const ObjFiber = _obj.ObjFiber;
-const NativeCtx = _obj.NativeCtx;
+const o = @import("../obj.zig");
 const VM = @import("../vm.zig").VM;
-const _value = @import("../value.zig");
-const Value = _value.Value;
+const v = @import("../value.zig");
 
-pub fn over(ctx: *NativeCtx) callconv(.c) c_int {
-    const self = ObjFiber.cast(ctx.vm.peek(0).obj()).?;
+pub fn over(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const self = o.ObjFiber.cast(ctx.vm.peek(0).obj()).?;
 
-    ctx.vm.push(Value.fromBoolean(self.fiber.status == .Over));
+    ctx.vm.push(v.Value.fromBoolean(self.fiber.status == .Over));
 
     return 1;
 }
 
-pub fn cancel(ctx: *NativeCtx) callconv(.c) c_int {
-    const self = ObjFiber.cast(ctx.vm.peek(0).obj()).?;
+pub fn cancel(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const self = o.ObjFiber.cast(ctx.vm.peek(0).obj()).?;
 
     // Main fiber can't be cancelled
     if (self.fiber.parent_fiber == null) {
@@ -27,10 +24,10 @@ pub fn cancel(ctx: *NativeCtx) callconv(.c) c_int {
     return 0;
 }
 
-pub fn isMain(ctx: *NativeCtx) callconv(.c) c_int {
-    const self = ObjFiber.cast(ctx.vm.peek(0).obj()).?;
+pub fn isMain(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const self = o.ObjFiber.cast(ctx.vm.peek(0).obj()).?;
 
-    ctx.vm.push(Value.fromBoolean(self.fiber.parent_fiber == null));
+    ctx.vm.push(v.Value.fromBoolean(self.fiber.parent_fiber == null));
 
     return 1;
 }

--- a/src/builtin/range.zig
+++ b/src/builtin/range.zig
@@ -1,5 +1,5 @@
 const obj = @import("../obj.zig");
-const Value = @import("../value.zig").Value;
+const v = @import("../value.zig");
 
 pub fn toList(ctx: *obj.NativeCtx) callconv(.c) c_int {
     const range = ctx.vm.peek(0).obj().access(obj.ObjRange, .Range, ctx.vm.gc).?;
@@ -31,20 +31,20 @@ pub fn toList(ctx: *obj.NativeCtx) callconv(.c) c_int {
         unreachable;
     };
 
-    ctx.vm.push(Value.fromObj(list.toObj()));
+    ctx.vm.push(v.Value.fromObj(list.toObj()));
 
     if (range.low < range.high) {
-        var i: i32 = range.low;
+        var i: v.Integer = range.low;
         while (i < range.high) : (i += 1) {
-            list.rawAppend(ctx.vm.gc, Value.fromInteger(i)) catch {
+            list.rawAppend(ctx.vm.gc, v.Value.fromInteger(i)) catch {
                 ctx.vm.panic("Out of memory");
                 unreachable;
             };
         }
     } else {
-        var i: i32 = range.low;
+        var i: v.Integer = range.low;
         while (i > range.high) : (i -= 1) {
-            list.rawAppend(ctx.vm.gc, Value.fromInteger(i)) catch {
+            list.rawAppend(ctx.vm.gc, v.Value.fromInteger(i)) catch {
                 ctx.vm.panic("Out of memory");
                 unreachable;
             };
@@ -58,7 +58,7 @@ pub fn len(ctx: *obj.NativeCtx) callconv(.c) c_int {
     const range = ctx.vm.peek(0).obj().access(obj.ObjRange, .Range, ctx.vm.gc).?;
 
     ctx.vm.push(
-        Value.fromInteger(
+        v.Value.fromInteger(
             if (range.low < range.high)
                 range.high - range.low
             else
@@ -73,7 +73,7 @@ pub fn invert(ctx: *obj.NativeCtx) callconv(.c) c_int {
     const range = ctx.vm.peek(0).obj().access(obj.ObjRange, .Range, ctx.vm.gc).?;
 
     ctx.vm.push(
-        Value.fromObj((ctx.vm.gc.allocateObject(
+        v.Value.fromObj((ctx.vm.gc.allocateObject(
             obj.ObjRange,
             .{
                 .high = range.low,
@@ -93,7 +93,7 @@ pub fn subsetOf(ctx: *obj.NativeCtx) callconv(.c) c_int {
     const rangeB = ctx.vm.peek(0).obj().access(obj.ObjRange, .Range, ctx.vm.gc).?;
 
     ctx.vm.push(
-        Value.fromBoolean(
+        v.Value.fromBoolean(
             @min(rangeA.low, rangeA.high) >= @min(rangeB.low, rangeB.high) and
                 @max(rangeA.low, rangeA.high) <= @max(rangeB.low, rangeB.high),
         ),
@@ -107,7 +107,7 @@ pub fn intersect(ctx: *obj.NativeCtx) callconv(.c) c_int {
     const rangeB = ctx.vm.peek(0).obj().access(obj.ObjRange, .Range, ctx.vm.gc).?;
 
     ctx.vm.push(
-        Value.fromObj((ctx.vm.gc.allocateObject(
+        v.Value.fromObj((ctx.vm.gc.allocateObject(
             obj.ObjRange,
             .{
                 .high = @max(
@@ -133,7 +133,7 @@ pub fn @"union"(ctx: *obj.NativeCtx) callconv(.c) c_int {
     const rangeB = ctx.vm.peek(0).obj().access(obj.ObjRange, .Range, ctx.vm.gc).?;
 
     ctx.vm.push(
-        Value.fromObj((ctx.vm.gc.allocateObject(
+        v.Value.fromObj((ctx.vm.gc.allocateObject(
             obj.ObjRange,
             .{
                 .high = @min(
@@ -156,7 +156,7 @@ pub fn @"union"(ctx: *obj.NativeCtx) callconv(.c) c_int {
 
 pub fn high(ctx: *obj.NativeCtx) callconv(.c) c_int {
     ctx.vm.push(
-        Value.fromInteger(
+        v.Value.fromInteger(
             ctx.vm.peek(0).obj().access(obj.ObjRange, .Range, ctx.vm.gc).?.high,
         ),
     );
@@ -166,7 +166,7 @@ pub fn high(ctx: *obj.NativeCtx) callconv(.c) c_int {
 
 pub fn low(ctx: *obj.NativeCtx) callconv(.c) c_int {
     ctx.vm.push(
-        Value.fromInteger(
+        v.Value.fromInteger(
             ctx.vm.peek(0).obj().access(obj.ObjRange, .Range, ctx.vm.gc).?.low,
         ),
     );
@@ -179,7 +179,7 @@ pub fn contains(ctx: *obj.NativeCtx) callconv(.c) c_int {
     const value = ctx.vm.peek(0).integer();
 
     ctx.vm.push(
-        Value.fromBoolean(
+        v.Value.fromBoolean(
             (range.high >= range.low and value >= range.low and value < range.high) or
                 (range.low >= range.high and value >= range.high and value < range.low),
         ),

--- a/src/builtin/str.zig
+++ b/src/builtin/str.zig
@@ -1,15 +1,10 @@
 const std = @import("std");
-const _obj = @import("../obj.zig");
-const ObjString = _obj.ObjString;
-const ObjList = _obj.ObjList;
-const ObjTypeDef = _obj.ObjTypeDef;
-const NativeCtx = _obj.NativeCtx;
+const o = @import("../obj.zig");
 const VM = @import("../vm.zig").VM;
-const _value = @import("../value.zig");
-const Value = _value.Value;
+const v = @import("../value.zig");
 
-pub fn trim(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn trim(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     const trimmed = std.mem.trim(u8, str.string, " \t\r\n");
 
@@ -21,11 +16,11 @@ pub fn trim(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn len(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn len(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     ctx.vm.push(
-        Value.fromInteger(
+        v.Value.fromInteger(
             @intCast(str.string.len),
         ),
     );
@@ -33,11 +28,11 @@ pub fn len(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn utf8Len(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn utf8Len(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     ctx.vm.push(
-        Value.fromInteger(
+        v.Value.fromInteger(
             @intCast(std.unicode.utf8CountCodepoints(str.string) catch 0),
         ),
     );
@@ -45,11 +40,11 @@ pub fn utf8Len(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn utf8Valid(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn utf8Valid(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     ctx.vm.push(
-        Value.fromBoolean(
+        v.Value.fromBoolean(
             std.unicode.utf8ValidateSlice(str.string),
         ),
     );
@@ -57,15 +52,15 @@ pub fn utf8Valid(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn utf8Codepoints(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn utf8Codepoints(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     const list_def_type = ctx.vm.gc.type_registry.getTypeDef(
-        ObjTypeDef{
+        o.ObjTypeDef{
             .def_type = .List,
             .optional = false,
             .resolved_type = .{
-                .List = ObjList.ListDef.init(
+                .List = o.ObjList.ListDef.init(
                     ctx.vm.gc.type_registry.str_type,
                     false,
                 ),
@@ -77,8 +72,8 @@ pub fn utf8Codepoints(ctx: *NativeCtx) callconv(.c) c_int {
     };
 
     var list = (ctx.vm.gc.allocateObject(
-        ObjList,
-        ObjList.init(ctx.vm.gc.allocator, list_def_type) catch {
+        o.ObjList,
+        o.ObjList.init(ctx.vm.gc.allocator, list_def_type) catch {
             ctx.vm.panic("Out of memory");
             unreachable;
         },
@@ -108,8 +103,8 @@ pub fn utf8Codepoints(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn repeat(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(1).obj()).?;
+pub fn repeat(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(1).obj()).?;
     const n = ctx.vm.peek(0).integer();
 
     var new_string: std.ArrayList(u8) = std.ArrayList(u8).init(ctx.vm.gc.allocator);
@@ -131,8 +126,8 @@ pub fn repeat(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn byte(ctx: *NativeCtx) callconv(.c) c_int {
-    const self = ObjString.cast(ctx.vm.peek(1).obj()).?;
+pub fn byte(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const self = o.ObjString.cast(ctx.vm.peek(1).obj()).?;
     const index = @min(
         @max(
             0,
@@ -142,7 +137,7 @@ pub fn byte(ctx: *NativeCtx) callconv(.c) c_int {
     );
 
     ctx.vm.push(
-        Value.fromInteger(
+        v.Value.fromInteger(
             @intCast(self.string[@intCast(index)]),
         ),
     );
@@ -150,28 +145,28 @@ pub fn byte(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn indexOf(ctx: *NativeCtx) callconv(.c) c_int {
-    const self = ObjString.cast(ctx.vm.peek(1).obj()).?;
-    const needle = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn indexOf(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const self = o.ObjString.cast(ctx.vm.peek(1).obj()).?;
+    const needle = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     const index = std.mem.indexOf(u8, self.string, needle.string);
 
     ctx.vm.push(
         if (index) |uindex|
-            Value.fromInteger(@intCast(uindex))
+            v.Value.fromInteger(@intCast(uindex))
         else
-            Value.Null,
+            v.Value.Null,
     );
 
     return 1;
 }
 
-pub fn startsWith(ctx: *NativeCtx) callconv(.c) c_int {
-    const self = ObjString.cast(ctx.vm.peek(1).obj()).?;
-    const needle = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn startsWith(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const self = o.ObjString.cast(ctx.vm.peek(1).obj()).?;
+    const needle = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     ctx.vm.push(
-        Value.fromBoolean(
+        v.Value.fromBoolean(
             std.mem.startsWith(u8, self.string, needle.string),
         ),
     );
@@ -179,12 +174,12 @@ pub fn startsWith(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn endsWith(ctx: *NativeCtx) callconv(.c) c_int {
-    const self = ObjString.cast(ctx.vm.peek(1).obj()).?;
-    const needle = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn endsWith(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const self = o.ObjString.cast(ctx.vm.peek(1).obj()).?;
+    const needle = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     ctx.vm.push(
-        Value.fromBoolean(
+        v.Value.fromBoolean(
             std.mem.endsWith(u8, self.string, needle.string),
         ),
     );
@@ -192,10 +187,10 @@ pub fn endsWith(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn replace(ctx: *NativeCtx) callconv(.c) c_int {
-    const self = ObjString.cast(ctx.vm.peek(2).obj()).?;
-    const needle = ObjString.cast(ctx.vm.peek(1).obj()).?;
-    const replacement = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn replace(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const self = o.ObjString.cast(ctx.vm.peek(2).obj()).?;
+    const needle = o.ObjString.cast(ctx.vm.peek(1).obj()).?;
+    const replacement = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     const new_string = std.mem.replaceOwned(
         u8,
@@ -218,8 +213,8 @@ pub fn replace(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn sub(ctx: *NativeCtx) callconv(.c) c_int {
-    const self = ObjString.cast(ctx.vm.peek(2).obj()).?;
+pub fn sub(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const self = o.ObjString.cast(ctx.vm.peek(2).obj()).?;
     const start = @max(
         0,
         ctx.vm.peek(1).integer(),
@@ -249,16 +244,16 @@ pub fn sub(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn split(ctx: *NativeCtx) callconv(.c) c_int {
-    const self = ObjString.cast(ctx.vm.peek(1).obj()).?;
-    const separator = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn split(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const self = o.ObjString.cast(ctx.vm.peek(1).obj()).?;
+    const separator = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     const list_def_type = ctx.vm.gc.type_registry.getTypeDef(
         .{
             .def_type = .List,
             .optional = false,
             .resolved_type = .{
-                .List = ObjList.ListDef.init(
+                .List = o.ObjList.ListDef.init(
                     ctx.vm.gc.type_registry.str_type,
                     false,
                 ),
@@ -270,8 +265,8 @@ pub fn split(ctx: *NativeCtx) callconv(.c) c_int {
     };
 
     var list = ctx.vm.gc.allocateObject(
-        ObjList,
-        ObjList.init(ctx.vm.gc.allocator, list_def_type) catch {
+        o.ObjList,
+        o.ObjList.init(ctx.vm.gc.allocator, list_def_type) catch {
             ctx.vm.panic("Out of memory");
             unreachable;
         },
@@ -313,8 +308,8 @@ pub fn split(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn encodeBase64(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn encodeBase64(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     const encoded = ctx.vm.gc.allocator.alloc(
         u8,
@@ -338,8 +333,8 @@ pub fn encodeBase64(ctx: *NativeCtx) callconv(.c) c_int {
 }
 
 // FIXME: signature should be fun decodeBase64(str self) > str !> DecodeError
-pub fn decodeBase64(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn decodeBase64(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     const size = std.base64.standard.Decoder.calcSizeForSlice(str.string) catch {
         ctx.vm.push((ctx.vm.gc.copyString("Could not decode string") catch {
@@ -374,8 +369,8 @@ pub fn decodeBase64(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn upper(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn upper(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     if (str.string.len == 0) {
         ctx.vm.push(str.toValue());
@@ -406,8 +401,8 @@ pub fn upper(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn lower(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn lower(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     if (str.string.len == 0) {
         ctx.vm.push(str.toValue());
@@ -438,8 +433,8 @@ pub fn lower(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn hex(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn hex(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     if (str.string.len == 0) {
         ctx.vm.push(str.toValue());
@@ -468,8 +463,8 @@ pub fn hex(ctx: *NativeCtx) callconv(.c) c_int {
     return 1;
 }
 
-pub fn bin(ctx: *NativeCtx) callconv(.c) c_int {
-    const str = ObjString.cast(ctx.vm.peek(0).obj()).?;
+pub fn bin(ctx: *o.NativeCtx) callconv(.c) c_int {
+    const str = o.ObjString.cast(ctx.vm.peek(0).obj()).?;
 
     if (str.string.len == 0) {
         ctx.vm.push(str.toValue());

--- a/src/jit_extern_api.zig
+++ b/src/jit_extern_api.zig
@@ -81,6 +81,7 @@ pub const ExternApi = enum {
 
     bz_valueDump,
     fmod,
+    dumpInt,
     memcpy,
 
     pub fn declare(self: ExternApi, jit: *JIT) !m.MIR_item_t {
@@ -189,12 +190,12 @@ pub const ExternApi = enum {
                         .size = undefined,
                     },
                     .{
-                        .type = m.MIR_T_I32,
+                        .type = m.MIR_T_I64,
                         .name = "low",
                         .size = undefined,
                     },
                     .{
-                        .type = m.MIR_T_I32,
+                        .type = m.MIR_T_I64,
                         .name = "high",
                         .size = undefined,
                     },
@@ -237,7 +238,7 @@ pub const ExternApi = enum {
                         .size = undefined,
                     },
                     .{
-                        .type = m.MIR_T_I32,
+                        .type = m.MIR_T_I64,
                         .name = "index",
                         .size = undefined,
                     },
@@ -1063,6 +1064,20 @@ pub const ExternApi = enum {
                     },
                 },
             ),
+            .dumpInt => m.MIR_new_proto_arr(
+                ctx,
+                self.pname(),
+                0,
+                &[_]m.MIR_type_t{},
+                1,
+                &[_]m.MIR_var_t{
+                    .{
+                        .type = m.MIR_T_U64,
+                        .name = "value",
+                        .size = undefined,
+                    },
+                },
+            ),
             .memcpy => m.MIR_new_proto_arr(
                 ctx,
                 self.pname(),
@@ -1165,6 +1180,7 @@ pub const ExternApi = enum {
 
             .bz_valueDump => @as(*anyopaque, @ptrFromInt(@intFromPtr(&api.Value.bz_valueDump))),
             .fmod => @as(*anyopaque, @ptrFromInt(@intFromPtr(&JIT.fmod))),
+            .dumpInt => @as(*anyopaque, @ptrFromInt(@intFromPtr(&JIT.dumpInt))),
             .memcpy => @as(*anyopaque, @ptrFromInt(@intFromPtr(&api.bz_memcpy))),
             else => {
                 io.print("{s}\n", .{self.name()});

--- a/src/lib/buzz_math.zig
+++ b/src/lib/buzz_math.zig
@@ -10,39 +10,39 @@ else
     std.os;
 
 pub export fn abs(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n_f: f64 = ctx.vm.bz_peek(0).double();
+    const n_f: api.Double = ctx.vm.bz_peek(0).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(if (n_f < 0) n_f * -1 else n_f));
+    ctx.vm.bz_push(api.Value.fromDouble(if (n_f < 0) n_f * -1 else n_f));
 
     return 1;
 }
 
 pub export fn acos(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n_f: f64 = ctx.vm.bz_peek(0).double();
+    const n_f: api.Double = ctx.vm.bz_peek(0).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(std.math.acos(n_f)));
+    ctx.vm.bz_push(api.Value.fromDouble(std.math.acos(n_f)));
 
     return 1;
 }
 
 pub export fn asin(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n_f: f64 = ctx.vm.bz_peek(0).double();
+    const n_f: api.Double = ctx.vm.bz_peek(0).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(std.math.asin(n_f)));
+    ctx.vm.bz_push(api.Value.fromDouble(std.math.asin(n_f)));
 
     return 1;
 }
 
 pub export fn atan(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n_f: f64 = ctx.vm.bz_peek(0).double();
+    const n_f: api.Double = ctx.vm.bz_peek(0).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(std.math.atan(n_f)));
+    ctx.vm.bz_push(api.Value.fromDouble(std.math.atan(n_f)));
 
     return 1;
 }
 
 pub export fn bzceil(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n_f: f64 = ctx.vm.bz_peek(0).double();
+    const n_f: api.Double = ctx.vm.bz_peek(0).double();
 
     ctx.vm.bz_push(api.Value.fromInteger(@intFromFloat(std.math.ceil(n_f))));
 
@@ -50,23 +50,23 @@ pub export fn bzceil(ctx: *api.NativeCtx) callconv(.c) c_int {
 }
 
 pub export fn bzcos(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n_f: f64 = ctx.vm.bz_peek(0).double();
+    const n_f: api.Double = ctx.vm.bz_peek(0).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(std.math.cos(n_f)));
+    ctx.vm.bz_push(api.Value.fromDouble(std.math.cos(n_f)));
 
     return 1;
 }
 
 pub export fn bzexp(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n_f: f64 = ctx.vm.bz_peek(0).double();
+    const n_f: api.Double = ctx.vm.bz_peek(0).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(std.math.exp(n_f)));
+    ctx.vm.bz_push(api.Value.fromDouble(std.math.exp(n_f)));
 
     return 1;
 }
 
 pub export fn bzfloor(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n_f: f64 = ctx.vm.bz_peek(0).double();
+    const n_f: api.Double = ctx.vm.bz_peek(0).double();
 
     ctx.vm.bz_push(api.Value.fromInteger(@intFromFloat(std.math.floor(n_f))));
 
@@ -74,10 +74,10 @@ pub export fn bzfloor(ctx: *api.NativeCtx) callconv(.c) c_int {
 }
 
 pub export fn bzlog(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const base_i: f64 = ctx.vm.bz_peek(1).double();
-    const n_f: f64 = ctx.vm.bz_peek(0).double();
+    const base_i: api.Double = ctx.vm.bz_peek(1).double();
+    const n_f: api.Double = ctx.vm.bz_peek(0).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(std.math.log(f64, base_i, n_f)));
+    ctx.vm.bz_push(api.Value.fromDouble(std.math.log(api.Double, base_i, n_f)));
 
     return 1;
 }
@@ -86,7 +86,7 @@ pub export fn maxDouble(ctx: *api.NativeCtx) callconv(.c) c_int {
     const a_f = ctx.vm.bz_peek(0).double();
     const b_f = ctx.vm.bz_peek(1).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(@max(a_f, b_f)));
+    ctx.vm.bz_push(api.Value.fromDouble(@max(a_f, b_f)));
 
     return 1;
 }
@@ -95,7 +95,7 @@ pub export fn minDouble(ctx: *api.NativeCtx) callconv(.c) c_int {
     const a_f = ctx.vm.bz_peek(0).double();
     const b_f = ctx.vm.bz_peek(1).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(@min(a_f, b_f)));
+    ctx.vm.bz_push(api.Value.fromDouble(@min(a_f, b_f)));
 
     return 1;
 }
@@ -119,25 +119,25 @@ pub export fn minInt(ctx: *api.NativeCtx) callconv(.c) c_int {
 }
 
 pub export fn bzsin(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n: f64 = ctx.vm.bz_peek(0).double();
+    const n: api.Double = ctx.vm.bz_peek(0).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(std.math.sin(n)));
+    ctx.vm.bz_push(api.Value.fromDouble(std.math.sin(n)));
 
     return 1;
 }
 
 pub export fn bzsqrt(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n_f: f64 = ctx.vm.bz_peek(0).double();
+    const n_f: api.Double = ctx.vm.bz_peek(0).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(std.math.sqrt(n_f)));
+    ctx.vm.bz_push(api.Value.fromDouble(std.math.sqrt(n_f)));
 
     return 1;
 }
 
 pub export fn bztan(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n: f64 = ctx.vm.bz_peek(0).double();
+    const n: api.Double = ctx.vm.bz_peek(0).double();
 
-    ctx.vm.bz_push(api.Value.fromFloat(std.math.tan(n)));
+    ctx.vm.bz_push(api.Value.fromDouble(std.math.tan(n)));
 
     return 1;
 }
@@ -146,24 +146,24 @@ pub export fn pow(ctx: *api.NativeCtx) callconv(.c) c_int {
     const n = ctx.vm.bz_peek(1);
     const p = ctx.vm.bz_peek(0);
 
-    const n_i: ?i32 = if (n.isInteger()) n.integer() else null;
-    const n_f: ?f64 = if (n.isFloat()) n.double() else null;
+    const n_i: ?api.Integer = if (n.isInteger()) n.integer() else null;
+    const n_f: ?api.Double = if (n.isFloat()) n.double() else null;
 
-    const p_i: ?i32 = if (p.isInteger()) p.integer() else null;
-    const p_f: ?f64 = if (p.isFloat()) p.double() else null;
+    const p_i: ?api.Integer = if (p.isInteger()) p.integer() else null;
+    const p_f: ?api.Double = if (p.isFloat()) p.double() else null;
 
     if (p_f) |pf| {
-        ctx.vm.bz_push(api.Value.fromFloat(
-            std.math.pow(f64, n_f orelse @as(f64, @floatFromInt(n_i.?)), pf),
+        ctx.vm.bz_push(api.Value.fromDouble(
+            std.math.pow(api.Double, n_f orelse @as(api.Double, @floatFromInt(n_i.?)), pf),
         ));
     } else if (n_f) |nf| {
-        ctx.vm.bz_push(api.Value.fromFloat(
-            std.math.pow(f64, nf, p_f orelse @as(f64, @floatFromInt(p_i.?))),
+        ctx.vm.bz_push(api.Value.fromDouble(
+            std.math.pow(api.Double, nf, p_f orelse @as(api.Double, @floatFromInt(p_i.?))),
         ));
     } else {
         ctx.vm.bz_push(
             api.Value.fromInteger(
-                std.math.powi(i32, n_i.?, p_i.?) catch |err| {
+                std.math.powi(api.Integer, n_i.?, p_i.?) catch |err| {
                     switch (err) {
                         error.Overflow => ctx.vm.pushError("errors.OverflowError", null),
                         error.Underflow => ctx.vm.pushError("errors.UnderflowError", null),

--- a/src/lib/buzz_os.zig
+++ b/src/lib/buzz_os.zig
@@ -9,7 +9,7 @@ pub export fn sleep(ctx: *api.NativeCtx) callconv(.c) c_int {
 }
 
 pub export fn time(ctx: *api.NativeCtx) callconv(.c) c_int {
-    ctx.vm.bz_push(api.Value.fromFloat(@as(f64, @floatFromInt(std.time.milliTimestamp()))));
+    ctx.vm.bz_push(api.Value.fromDouble(@as(api.Double, @floatFromInt(std.time.milliTimestamp()))));
 
     return 1;
 }
@@ -89,7 +89,7 @@ pub export fn tmpFilename(ctx: *api.NativeCtx) callconv(.c) c_int {
 
     var random_part = std.ArrayList(u8).init(api.VM.allocator);
     defer random_part.deinit();
-    random_part.writer().print("{x}", .{std.crypto.random.int(i32)}) catch {
+    random_part.writer().print("{x}", .{std.crypto.random.int(api.Integer)}) catch {
         ctx.vm.bz_panic("Out of memory", "Out of memory".len);
         unreachable;
     };
@@ -130,7 +130,7 @@ pub export fn tmpFilename(ctx: *api.NativeCtx) callconv(.c) c_int {
 
 // If it was named `exit` it would be considered by zig as a callback when std.process.exit is called
 pub export fn buzzExit(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const exitCode: i32 = ctx.vm.bz_peek(0).integer();
+    const exitCode: api.Integer = ctx.vm.bz_peek(0).integer();
 
     std.process.exit(@intCast(exitCode));
 
@@ -334,7 +334,7 @@ pub export fn SocketConnect(ctx: *api.NativeCtx) callconv(.c) c_int {
     var len: usize = 0;
     const address_value = api.Value.bz_valueToString(ctx.vm.bz_peek(2), &len);
     const address = if (len > 0) address_value.?[0..len] else "";
-    const port: ?i32 = ctx.vm.bz_peek(1).integer();
+    const port: ?api.Integer = ctx.vm.bz_peek(1).integer();
     if (port == null or port.? < 0) {
         ctx.vm.pushError("errors.InvalidArgumentError", null);
 
@@ -439,7 +439,7 @@ fn handleReadAllError(ctx: *api.NativeCtx, err: anytype) void {
 }
 
 pub export fn SocketRead(ctx: *api.NativeCtx) callconv(.c) c_int {
-    const n: i32 = ctx.vm.bz_peek(0).integer();
+    const n: api.Integer = ctx.vm.bz_peek(0).integer();
     if (n < 0) {
         ctx.vm.pushError("errors.InvalidArgumentError", null);
 
@@ -665,7 +665,7 @@ pub export fn SocketServerStart(ctx: *api.NativeCtx) callconv(.c) c_int {
     var len: usize = 0;
     const address_value = api.Value.bz_valueToString(ctx.vm.bz_peek(3), &len);
     const address = if (len > 0) address_value.?[0..len] else "";
-    const port: ?i32 = ctx.vm.bz_peek(2).integer();
+    const port: ?api.Integer = ctx.vm.bz_peek(2).integer();
     if (port == null or port.? < 0) {
         ctx.vm.pushError("errors.InvalidArgumentError", null);
 

--- a/src/lib/buzz_std.zig
+++ b/src/lib/buzz_std.zig
@@ -26,7 +26,7 @@ pub export fn random(ctx: *api.NativeCtx) callconv(.c) c_int {
     ctx.vm.bz_push(
         api.Value.fromInteger(
             std.crypto.random.intRangeAtMost(
-                i32,
+                api.Integer,
                 if (min.isInteger())
                     min.integer()
                 else
@@ -70,7 +70,7 @@ pub export fn toDouble(ctx: *api.NativeCtx) callconv(.c) c_int {
     const value = ctx.vm.bz_peek(0);
 
     ctx.vm.bz_push(
-        api.Value.fromFloat(@floatFromInt(value.integer())),
+        api.Value.fromDouble(@floatFromInt(value.integer())),
     );
 
     return 1;
@@ -105,7 +105,7 @@ pub export fn parseInt(ctx: *api.NativeCtx) callconv(.c) c_int {
 
     const string_slice = string.?[0..len];
 
-    const number = std.fmt.parseInt(i32, string_slice, 10) catch {
+    const number = std.fmt.parseInt(api.Integer, string_slice, 10) catch {
         ctx.vm.bz_push(api.Value.Null);
 
         return 1;
@@ -166,7 +166,7 @@ pub export fn parseDouble(ctx: *api.NativeCtx) callconv(.c) c_int {
         return 1;
     };
 
-    ctx.vm.bz_push(api.Value.fromFloat(number));
+    ctx.vm.bz_push(api.Value.fromDouble(number));
 
     return 1;
 }

--- a/src/obj.zig
+++ b/src/obj.zig
@@ -12,8 +12,9 @@ const Parser = @import("Parser.zig");
 const _memory = @import("memory.zig");
 const GarbageCollector = _memory.GarbageCollector;
 const TypeRegistry = _memory.TypeRegistry;
-const Integer = @import("value.zig").Integer;
-const Value = @import("value.zig").Value;
+const v = @import("value.zig");
+const Integer = v.Integer;
+const Value = v.Value;
 const Token = @import("Token.zig");
 const is_wasm = builtin.cpu.arch.isWasm();
 const BuildOptions = @import("build_options");
@@ -990,9 +991,9 @@ pub const ObjString = struct {
         return vm.gc.copyString(new_string.items);
     }
 
-    pub fn next(self: *Self, vm: *VM, str_index: ?i32) !?i32 {
+    pub fn next(self: *Self, vm: *VM, str_index: ?Integer) !?Integer {
         if (str_index) |index| {
-            if (index < 0 or index >= @as(i32, @intCast(self.string.len))) {
+            if (index < 0 or index >= @as(Integer, @intCast(self.string.len))) {
                 try vm.throw(
                     VM.Error.OutOfBound,
                     (try vm.gc.copyString("Out of bound access to str")).toValue(),
@@ -1001,12 +1002,12 @@ pub const ObjString = struct {
                 );
             }
 
-            return if (index + 1 >= @as(i32, @intCast(self.string.len)))
+            return if (index + 1 >= @as(Integer, @intCast(self.string.len)))
                 null
             else
                 index + 1;
         } else {
-            return if (self.string.len > 0) @as(i32, 0) else null;
+            return if (self.string.len > 0) @as(Integer, 0) else null;
         }
     }
 
@@ -2074,9 +2075,9 @@ pub const ObjList = struct {
     }
 
     // Used also by the VM
-    pub fn rawNext(self: *Self, vm: *VM, list_index: ?i32) !?i32 {
+    pub fn rawNext(self: *Self, vm: *VM, list_index: ?Integer) !?Integer {
         if (list_index) |index| {
-            if (index < 0 or index >= @as(i32, @intCast(self.items.items.len))) {
+            if (index < 0 or index >= @as(Integer, @intCast(self.items.items.len))) {
                 try vm.throw(
                     VM.Error.OutOfBound,
                     (try vm.gc.copyString("Out of bound access to list")).toValue(),
@@ -2085,12 +2086,12 @@ pub const ObjList = struct {
                 );
             }
 
-            return if (index + 1 >= @as(i32, @intCast(self.items.items.len)))
+            return if (index + 1 >= @as(Integer, @intCast(self.items.items.len)))
                 null
             else
                 index + 1;
         } else {
-            return if (self.items.items.len > 0) @as(i32, 0) else null;
+            return if (self.items.items.len > 0) @as(Integer, 0) else null;
         }
     }
 

--- a/src/value.zig
+++ b/src/value.zig
@@ -6,7 +6,7 @@ const VM = @import("vm.zig").VM;
 const GarbageCollector = @import("memory.zig").GarbageCollector;
 
 pub const Double = f64;
-pub const Integer = i32;
+pub const Integer = i48;
 const Tag = u3;
 
 pub const Value = packed struct {
@@ -22,23 +22,21 @@ pub const Value = packed struct {
 
     /// QNAN and one extra bit to the right.
     pub const TaggedValueMask: u64 = 0x7ffc000000000000;
+    pub const TaggedUpperValueMask: u64 = 0xffff000000000000;
 
     /// TaggedMask + Sign bit indicates a pointer value.
     pub const PointerMask: u64 = TaggedValueMask | SignMask;
-
     pub const BooleanMask: u64 = TaggedValueMask | (@as(u64, TagBoolean) << 32);
     pub const FalseMask: u64 = BooleanMask;
     pub const TrueBitMask: u64 = 1;
     pub const TrueMask: u64 = BooleanMask | TrueBitMask;
-
-    // FIXME: Their's room to have a bigger integer. How would MIR handle it?
-    pub const IntegerMask: u64 = TaggedValueMask | (@as(u64, TagInteger) << 32);
+    pub const IntegerMask: u64 = TaggedValueMask | (@as(u64, TagInteger) << 49);
     pub const NullMask: u64 = TaggedValueMask | (@as(u64, TagNull) << 32);
     pub const VoidMask: u64 = TaggedValueMask | (@as(u64, TagVoid) << 32);
     pub const ErrorMask: u64 = TaggedValueMask | (@as(u64, TagError) << 32);
 
     pub const TagMask: u32 = (1 << 3) - 1;
-    pub const TaggedPrimitiveMask = TaggedValueMask | (@as(u64, TagMask) << 32);
+    pub const TaggedPrimitiveMask = TaggedValueMask | (@as(u64, TagMask) << 32) | IntegerMask;
 
     val: u64,
 
@@ -53,11 +51,11 @@ pub const Value = packed struct {
         return if (val) True else False;
     }
 
-    pub inline fn fromInteger(val: i32) Value {
-        return .{ .val = IntegerMask | @as(u32, @bitCast(val)) };
+    pub inline fn fromInteger(val: Integer) Value {
+        return .{ .val = IntegerMask | @as(u48, @bitCast(val)) };
     }
 
-    pub inline fn fromFloat(val: f64) Value {
+    pub inline fn fromDouble(val: Double) Value {
         return .{ .val = @as(u64, @bitCast(val)) };
     }
 
@@ -74,15 +72,15 @@ pub const Value = packed struct {
     }
 
     pub inline fn isInteger(self: Value) bool {
-        return self.val & (TaggedPrimitiveMask | SignMask) == IntegerMask;
+        return self.val & (TaggedUpperValueMask | SignMask) == IntegerMask;
     }
 
-    pub inline fn isFloat(self: Value) bool {
+    pub inline fn isDouble(self: Value) bool {
         return !self.isBool() and !self.isError() and !self.isInteger() and !self.isNull() and !self.isObj() and !self.isVoid();
     }
 
     pub inline fn isNumber(self: Value) bool {
-        return self.isFloat() or self.isInteger();
+        return self.isDouble() or self.isInteger();
     }
 
     pub inline fn isObj(self: Value) bool {
@@ -105,28 +103,28 @@ pub const Value = packed struct {
         return self.val == TrueMask;
     }
 
-    pub inline fn integer(self: Value) i32 {
-        return @as(i32, @bitCast(@as(u32, @intCast(self.val & 0xffffffff))));
+    pub inline fn integer(self: Value) Integer {
+        return @bitCast(@as(u48, @intCast(self.val & 0xffffffffffff)));
     }
 
-    pub inline fn double(self: Value) f64 {
-        return @as(f64, @bitCast(self.val));
+    pub inline fn double(self: Value) Double {
+        return @bitCast(self.val);
     }
 
     pub inline fn obj(self: Value) *o.Obj {
-        return @as(*o.Obj, @ptrFromInt(@as(usize, @truncate(self.val & ~PointerMask))));
+        return @ptrFromInt(@as(usize, @truncate(self.val & ~PointerMask)));
     }
 
     pub inline fn booleanOrNull(self: Value) ?bool {
         return if (self.isBool()) self.boolean() else null;
     }
 
-    pub inline fn integerOrNull(self: Value) ?i32 {
+    pub inline fn integerOrNull(self: Value) ?Integer {
         return if (self.isInteger()) self.integer() else null;
     }
 
-    pub inline fn floatOrNull(self: Value) ?f64 {
-        return if (self.isFloat()) self.double() else null;
+    pub inline fn doubleOrNull(self: Value) ?Double {
+        return if (self.isDouble()) self.double() else null;
     }
 
     pub inline fn objOrNull(self: Value) ?*o.Obj {
@@ -138,13 +136,16 @@ pub const Value = packed struct {
             return try self.obj().typeOf(gc);
         }
 
-        if (self.isFloat()) {
+        if (self.isDouble()) {
             return gc.type_registry.float_type;
+        }
+
+        if (self.isInteger()) {
+            return gc.type_registry.int_type;
         }
 
         return switch (self.getTag()) {
             TagBoolean => gc.type_registry.bool_type,
-            TagInteger => gc.type_registry.int_type,
             TagNull, TagVoid => gc.type_registry.void_type,
             else => gc.type_registry.float_type,
         };
@@ -173,14 +174,18 @@ pub const Value = packed struct {
             return;
         }
 
-        if (self.isFloat()) {
+        if (self.isDouble()) {
             try writer.print("{d}", .{self.double()});
+            return;
+        }
+
+        if (self.isInteger()) {
+            try writer.print("{d}", .{self.integer()});
             return;
         }
 
         switch (self.getTag()) {
             TagBoolean => try writer.print("{}", .{self.boolean()}),
-            TagInteger => try writer.print("{d}", .{self.integer()}),
             TagNull => try writer.print("null", .{}),
             TagVoid => try writer.print("void", .{}),
             else => try writer.print("{d}", .{self.double()}),
@@ -199,21 +204,21 @@ pub const Value = packed struct {
             return a.obj().eql(b.obj());
         }
 
-        if (a.isInteger() or a.isFloat()) {
-            const a_f: ?f64 = if (a.isFloat()) a.double() else null;
-            const b_f: ?f64 = if (b.isFloat()) b.double() else null;
-            const a_i: ?i32 = if (a.isInteger()) a.integer() else null;
-            const b_i: ?i32 = if (b.isInteger()) b.integer() else null;
+        if (a.isInteger() or a.isDouble()) {
+            const a_f = if (a.isDouble()) a.double() else null;
+            const b_f = if (b.isDouble()) b.double() else null;
+            const a_i = if (a.isInteger()) a.integer() else null;
+            const b_i = if (b.isInteger()) b.integer() else null;
 
             if (a_f) |af| {
                 if (b_f) |bf| {
                     return af == bf;
                 } else {
-                    return af == @as(f64, @floatFromInt(b_i.?));
+                    return af == @as(Double, @floatFromInt(b_i.?));
                 }
             } else {
                 if (b_f) |bf| {
-                    return @as(f64, @floatFromInt(a_i.?)) == bf;
+                    return @as(Double, @floatFromInt(a_i.?)) == bf;
                 } else {
                     return a_i.? == b_i.?;
                 }
@@ -239,13 +244,16 @@ pub const Value = packed struct {
             return value.obj().is(type_def);
         }
 
-        if (value.isFloat()) {
+        if (value.isDouble()) {
             return type_def.def_type == .Double;
+        }
+
+        if (value.isInteger()) {
+            return type_def.def_type == .Integer;
         }
 
         return switch (value.getTag()) {
             TagBoolean => type_def.def_type == .Bool,
-            TagInteger => type_def.def_type == .Integer,
             // TODO: this one is ambiguous at runtime, is it the `null` constant? or an optional local with a null value?
             TagNull => type_def.def_type == .Void or type_def.optional,
             TagVoid => type_def.def_type == .Void,
@@ -258,13 +266,16 @@ pub const Value = packed struct {
             return value.obj().typeEql(type_def);
         }
 
-        if (value.isFloat()) {
+        if (value.isDouble()) {
             return type_def.def_type == .Double;
+        }
+
+        if (value.isInteger()) {
+            return type_def.def_type == .Integer;
         }
 
         return switch (value.getTag()) {
             TagBoolean => type_def.def_type == .Bool,
-            TagInteger => type_def.def_type == .Integer,
             // TODO: this one is ambiguous at runtime, is it the `null` constant? or an optional local with a null value?
             TagNull => type_def.def_type == .Void or type_def.optional,
             TagVoid => type_def.def_type == .Void,

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const Value = @import("value.zig").Value;
+const v = @import("value.zig");
+const Value = v.Value;
 const Chunk = @import("Chunk.zig");
 const Ast = @import("Ast.zig");
 const disassembler = @import("disassembler.zig");
@@ -1188,7 +1189,7 @@ pub const VM = struct {
         if (value.isInteger()) {
             self.push(Value.fromInteger(-%value.integer()));
         } else {
-            self.push(Value.fromFloat(-value.double()));
+            self.push(Value.fromDouble(-value.double()));
         }
 
         const next_full_instruction: u32 = self.readInstruction();
@@ -2103,7 +2104,7 @@ pub const VM = struct {
     }
 
     fn OP_EXPORT(self: *Self, _: *CallFrame, _: u32, _: Chunk.OpCode, arg: u24) void {
-        self.push(Value.fromInteger(@as(i32, @intCast(arg))));
+        self.push(Value.fromInteger(@as(v.Integer, @intCast(arg))));
 
         // Ends program, so we don't call dispatch
     }
@@ -3394,7 +3395,7 @@ pub const VM = struct {
     fn OP_BNOT(self: *Self, _: *CallFrame, _: u32, _: Chunk.OpCode, _: u24) void {
         const value = self.pop();
 
-        self.push(Value.fromInteger(~(if (value.isInteger()) value.integer() else @as(i32, @intFromFloat(value.double())))));
+        self.push(Value.fromInteger(~value.integer()));
 
         const next_full_instruction: u32 = self.readInstruction();
         @call(
@@ -3414,20 +3415,20 @@ pub const VM = struct {
         const right_value = self.pop();
         const left_value = self.pop();
 
-        const left_f: ?f64 = if (left_value.isFloat()) left_value.double() else null;
-        const left_i: ?i32 = if (left_value.isInteger()) left_value.integer() else null;
-        const right_f: ?f64 = if (right_value.isFloat()) right_value.double() else null;
-        const right_i: ?i32 = if (right_value.isInteger()) right_value.integer() else null;
+        const left_f: ?v.Double = if (left_value.isDouble()) left_value.double() else null;
+        const left_i: ?v.Integer = if (left_value.isInteger()) left_value.integer() else null;
+        const right_f: ?v.Double = if (right_value.isDouble()) right_value.double() else null;
+        const right_i: ?v.Integer = if (right_value.isInteger()) right_value.integer() else null;
 
         if (left_f) |lf| {
             if (right_f) |rf| {
                 self.push(Value.fromBoolean(lf > rf));
             } else {
-                self.push(Value.fromBoolean(lf > @as(f64, @floatFromInt(right_i.?))));
+                self.push(Value.fromBoolean(lf > @as(v.Double, @floatFromInt(right_i.?))));
             }
         } else {
             if (right_f) |rf| {
-                self.push(Value.fromBoolean(@as(f64, @floatFromInt(left_i.?)) > rf));
+                self.push(Value.fromBoolean(@as(v.Double, @floatFromInt(left_i.?)) > rf));
             } else {
                 self.push(Value.fromBoolean(left_i.? > right_i.?));
             }
@@ -3451,20 +3452,20 @@ pub const VM = struct {
         const right_value = self.pop();
         const left_value = self.pop();
 
-        const left_f: ?f64 = if (left_value.isFloat()) left_value.double() else null;
-        const left_i: ?i32 = if (left_value.isInteger()) left_value.integer() else null;
-        const right_f: ?f64 = if (right_value.isFloat()) right_value.double() else null;
-        const right_i: ?i32 = if (right_value.isInteger()) right_value.integer() else null;
+        const left_f: ?v.Double = if (left_value.isDouble()) left_value.double() else null;
+        const left_i: ?v.Integer = if (left_value.isInteger()) left_value.integer() else null;
+        const right_f: ?v.Double = if (right_value.isDouble()) right_value.double() else null;
+        const right_i: ?v.Integer = if (right_value.isInteger()) right_value.integer() else null;
 
         if (left_f) |lf| {
             if (right_f) |rf| {
                 self.push(Value.fromBoolean(lf < rf));
             } else {
-                self.push(Value.fromBoolean(lf < @as(f64, @floatFromInt(right_i.?))));
+                self.push(Value.fromBoolean(lf < @as(v.Double, @floatFromInt(right_i.?))));
             }
         } else {
             if (right_f) |rf| {
-                self.push(Value.fromBoolean(@as(f64, @floatFromInt(left_i.?)) < rf));
+                self.push(Value.fromBoolean(@as(v.Double, @floatFromInt(left_i.?)) < rf));
             } else {
                 self.push(Value.fromBoolean(left_i.? < right_i.?));
             }
@@ -3615,7 +3616,7 @@ pub const VM = struct {
         const right = self.pop().double();
         const left = self.pop().double();
 
-        self.push(Value.fromFloat(left + right));
+        self.push(Value.fromDouble(left + right));
 
         const next_full_instruction: u32 = self.readInstruction();
         @call(
@@ -3635,13 +3636,13 @@ pub const VM = struct {
         const right: Value = self.pop();
         const left: Value = self.pop();
 
-        const right_f: ?f64 = if (right.isFloat()) right.double() else null;
-        const left_f: ?f64 = if (left.isFloat()) left.double() else null;
-        const right_i: ?i32 = if (right.isInteger()) right.integer() else null;
-        const left_i: ?i32 = if (left.isInteger()) left.integer() else null;
+        const right_f: ?v.Double = if (right.isDouble()) right.double() else null;
+        const left_f: ?v.Double = if (left.isDouble()) left.double() else null;
+        const right_i: ?v.Integer = if (right.isInteger()) right.integer() else null;
+        const left_i: ?v.Integer = if (left.isInteger()) left.integer() else null;
 
         if (right_f != null or left_f != null) {
-            self.push(Value.fromFloat((left_f orelse @as(f64, @floatFromInt(left_i.?))) - (right_f orelse @as(f64, @floatFromInt(right_i.?)))));
+            self.push(Value.fromDouble((left_f orelse @as(v.Double, @floatFromInt(left_i.?))) - (right_f orelse @as(v.Double, @floatFromInt(right_i.?)))));
         } else {
             self.push(Value.fromInteger(left_i.? -% right_i.?));
         }
@@ -3664,13 +3665,13 @@ pub const VM = struct {
         const right: Value = self.pop();
         const left: Value = self.pop();
 
-        const right_f: ?f64 = if (right.isFloat()) right.double() else null;
-        const left_f: ?f64 = if (left.isFloat()) left.double() else null;
-        const right_i: ?i32 = if (right.isInteger()) right.integer() else null;
-        const left_i: ?i32 = if (left.isInteger()) left.integer() else null;
+        const right_f: ?v.Double = if (right.isDouble()) right.double() else null;
+        const left_f: ?v.Double = if (left.isDouble()) left.double() else null;
+        const right_i: ?v.Integer = if (right.isInteger()) right.integer() else null;
+        const left_i: ?v.Integer = if (left.isInteger()) left.integer() else null;
 
         if (right_f != null or left_f != null) {
-            self.push(Value.fromFloat((left_f orelse @as(f64, @floatFromInt(left_i.?))) * (right_f orelse @as(f64, @floatFromInt(right_i.?)))));
+            self.push(Value.fromDouble((left_f orelse @as(v.Double, @floatFromInt(left_i.?))) * (right_f orelse @as(v.Double, @floatFromInt(right_i.?)))));
         } else {
             self.push(Value.fromInteger(left_i.? *% right_i.?));
         }
@@ -3693,15 +3694,15 @@ pub const VM = struct {
         const right: Value = self.pop();
         const left: Value = self.pop();
 
-        const right_f: ?f64 = if (right.isFloat()) right.double() else null;
-        const left_f: ?f64 = if (left.isFloat()) left.double() else null;
-        const right_i: ?i32 = if (right.isInteger()) right.integer() else null;
-        const left_i: ?i32 = if (left.isInteger()) left.integer() else null;
+        const right_f: ?v.Double = if (right.isDouble()) right.double() else null;
+        const left_f: ?v.Double = if (left.isDouble()) left.double() else null;
+        const right_i: ?v.Integer = if (right.isInteger()) right.integer() else null;
+        const left_i: ?v.Integer = if (left.isInteger()) left.integer() else null;
 
         if (left_f != null or right_f != null) {
             self.push(
-                Value.fromFloat(
-                    (left_f orelse @as(f64, @floatFromInt(left_i.?))) / (right_f orelse @as(f64, @floatFromInt(right_i.?))),
+                Value.fromDouble(
+                    (left_f orelse @as(v.Double, @floatFromInt(left_i.?))) / (right_f orelse @as(v.Double, @floatFromInt(right_i.?))),
                 ),
             );
         } else {
@@ -3728,17 +3729,17 @@ pub const VM = struct {
         const right: Value = self.pop();
         const left: Value = self.pop();
 
-        const right_f: ?f64 = if (right.isFloat()) right.double() else null;
-        const left_f: ?f64 = if (left.isFloat()) left.double() else null;
-        const right_i: ?i32 = if (right.isInteger()) right.integer() else null;
-        const left_i: ?i32 = if (left.isInteger()) left.integer() else null;
+        const right_f: ?v.Double = if (right.isDouble()) right.double() else null;
+        const left_f: ?v.Double = if (left.isDouble()) left.double() else null;
+        const right_i: ?v.Integer = if (right.isInteger()) right.integer() else null;
+        const left_i: ?v.Integer = if (left.isInteger()) left.integer() else null;
 
         if (right_f != null or left_f != null) {
             self.push(
-                Value.fromFloat(
+                Value.fromDouble(
                     @mod(
-                        (left_f orelse @as(f64, @floatFromInt(left_i.?))),
-                        (right_f orelse @as(f64, @floatFromInt(right_i.?))),
+                        (left_f orelse @as(v.Double, @floatFromInt(left_i.?))),
+                        (right_f orelse @as(v.Double, @floatFromInt(right_i.?))),
                     ),
                 ),
             );
@@ -3768,12 +3769,7 @@ pub const VM = struct {
         const right: Value = self.pop();
         const left: Value = self.pop();
 
-        const right_f: ?f64 = if (right.isFloat()) right.double() else null;
-        const left_f: ?f64 = if (left.isFloat()) left.double() else null;
-        const right_i: ?i32 = if (right.isInteger()) right.integer() else null;
-        const left_i: ?i32 = if (left.isInteger()) left.integer() else null;
-
-        self.push(Value.fromInteger((left_i orelse @as(i32, @intFromFloat(left_f.?))) & (right_i orelse @as(i32, @intFromFloat(right_f.?)))));
+        self.push(Value.fromInteger(left.integer() & right.integer()));
 
         const next_full_instruction: u32 = self.readInstruction();
         @call(
@@ -3793,12 +3789,7 @@ pub const VM = struct {
         const right: Value = self.pop();
         const left: Value = self.pop();
 
-        const right_f: ?f64 = if (right.isFloat()) right.double() else null;
-        const left_f: ?f64 = if (left.isFloat()) left.double() else null;
-        const right_i: ?i32 = if (right.isInteger()) right.integer() else null;
-        const left_i: ?i32 = if (left.isInteger()) left.integer() else null;
-
-        self.push(Value.fromInteger((left_i orelse @as(i32, @intFromFloat(left_f.?))) | (right_i orelse @as(i32, @intFromFloat(right_f.?)))));
+        self.push(Value.fromInteger(left.integer() | right.integer()));
 
         const next_full_instruction: u32 = self.readInstruction();
         @call(
@@ -3818,11 +3809,7 @@ pub const VM = struct {
         const right: Value = self.pop();
         const left: Value = self.pop();
 
-        const right_f: ?f64 = if (right.isFloat()) right.double() else null;
-        const left_f: ?f64 = if (left.isFloat()) left.double() else null;
-        const right_i: ?i32 = if (right.isInteger()) right.integer() else null;
-        const left_i: ?i32 = if (left.isInteger()) left.integer() else null;
-        self.push(Value.fromInteger((left_i orelse @as(i32, @intFromFloat(left_f.?))) ^ (right_i orelse @as(i32, @intFromFloat(right_f.?)))));
+        self.push(Value.fromInteger(left.integer() ^ right.integer()));
 
         const next_full_instruction: u32 = self.readInstruction();
         @call(
@@ -3839,26 +3826,20 @@ pub const VM = struct {
     }
 
     fn OP_SHL(self: *Self, _: *CallFrame, _: u32, _: Chunk.OpCode, _: u24) void {
-        const right: Value = self.pop();
-        const left: Value = self.pop();
+        const right = self.pop().integer();
+        const left = self.pop().integer();
 
-        const right_f: ?f64 = if (right.isFloat()) right.double() else null;
-        const left_f: ?f64 = if (left.isFloat()) left.double() else null;
-        const right_i: ?i32 = if (right.isInteger()) right.integer() else null;
-        const left_i: ?i32 = if (left.isInteger()) left.integer() else null;
-        const b: i32 = right_i orelse @intFromFloat(right_f.?);
-
-        if (b < 0) {
-            if (b * -1 > std.math.maxInt(u5)) {
+        if (right < 0) {
+            if (right * -1 > std.math.maxInt(u5)) {
                 self.push(Value.fromInteger(0));
             } else {
-                self.push(Value.fromInteger((left_i orelse @as(i32, @intFromFloat(left_f.?))) >> @as(u5, @truncate(@as(u64, @intCast(b * -1))))));
+                self.push(Value.fromInteger(left >> @intCast(right * -1)));
             }
         } else {
-            if (b > std.math.maxInt(u5)) {
+            if (right > std.math.maxInt(u5)) {
                 self.push(Value.fromInteger(0));
             } else {
-                self.push(Value.fromInteger((left_i orelse @as(i32, @intFromFloat(left_f.?))) << @as(u5, @truncate(@as(u64, @intCast(b))))));
+                self.push(Value.fromInteger(left << @as(u5, @truncate(@as(u64, @intCast(right))))));
             }
         }
 
@@ -3877,26 +3858,20 @@ pub const VM = struct {
     }
 
     fn OP_SHR(self: *Self, _: *CallFrame, _: u32, _: Chunk.OpCode, _: u24) void {
-        const right: Value = self.pop();
-        const left: Value = self.pop();
+        const right = self.pop().integer();
+        const left = self.pop().integer();
 
-        const right_f: ?f64 = if (right.isFloat()) right.double() else null;
-        const left_f: ?f64 = if (left.isFloat()) left.double() else null;
-        const right_i: ?i32 = if (right.isInteger()) right.integer() else null;
-        const left_i: ?i32 = if (left.isInteger()) left.integer() else null;
-        const b: i32 = right_i orelse @intFromFloat(right_f.?);
-
-        if (b < 0) {
-            if (b * -1 > std.math.maxInt(u5)) {
+        if (right < 0) {
+            if (right * -1 > std.math.maxInt(u5)) {
                 self.push(Value.fromInteger(0));
             } else {
-                self.push(Value.fromInteger((left_i orelse @as(i32, @intFromFloat(left_f.?))) << @as(u5, @truncate(@as(u64, @intCast(b * -1))))));
+                self.push(Value.fromInteger(left << @as(u5, @truncate(@as(u64, @intCast(right * -1))))));
             }
         } else {
-            if (b > std.math.maxInt(u5)) {
+            if (right > std.math.maxInt(u5)) {
                 self.push(Value.fromInteger(0));
             } else {
-                self.push(Value.fromInteger((left_i orelse @as(i32, @intFromFloat(left_f.?))) >> @as(u5, @truncate(@as(u64, @intCast(b))))));
+                self.push(Value.fromInteger(left >> @as(u5, @truncate(@as(u64, @intCast(right))))));
             }
         }
 
@@ -4303,7 +4278,7 @@ pub const VM = struct {
                         .{
                             @tagName(self.current_ast.nodes.items(.tag)[node]),
                             self.currentFrame().?.closure.function.type_def.resolved_type.?.Function.name.string,
-                            @as(f64, @floatFromInt(timer.read())) / 1000000,
+                            @as(v.Double, @floatFromInt(timer.read())) / 1000000,
                         },
                     );
                 }
@@ -4650,7 +4625,7 @@ pub const VM = struct {
                         "Compiled function `{s}` in {d} ms\n",
                         .{
                             closure.function.type_def.resolved_type.?.Function.name.string,
-                            @as(f64, @floatFromInt(timer.read())) / 1000000,
+                            @as(v.Double, @floatFromInt(timer.read())) / 1000000,
                         },
                     );
                 }

--- a/tests/039-buffer.buzz
+++ b/tests/039-buffer.buzz
@@ -10,7 +10,7 @@ test "Reading and writing in a buffer" {
     buffer.writeBoolean(true);
 
     final expected = [
-        11, 0, 0, 0,                                          // "hello world".len()
+        11, 0, 0, 0, 0, 0,                                    // "hello world".len()
         104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, // "hello world"
         158, 239, 167, 198, 75, 89, 147, 64,                  // 1238.324
         1,                                                    // true
@@ -24,7 +24,8 @@ test "Reading and writing in a buffer" {
     final len = buffer.readInt() ?? -1;
     std\assert(len == 11, message: "could read number");
 
-    std\assert(buffer.read(len) == "hello world", message: "could read n bytes");
+    final res = buffer.read(len);
+    std\assert(res == "hello world", message: "could read n bytes got `{res}`");
     std\assert(buffer.readDouble() == 1238.324, message: "could read double");
     std\assert(buffer.readBoolean() == true, message: "could read boolean");
 

--- a/tests/040-bitwise.buzz
+++ b/tests/040-bitwise.buzz
@@ -1,10 +1,22 @@
 import "std";
 
-test "Bitwise" {
+test "Bitwise (constant folded)" {
     std\assert(15 << 3 == 120, message: "<<");
     std\assert(15 >> 3 == 1, message: ">>");
     std\assert(15 ^ 3 == 12, message: "^");
     std\assert(15 | 3 == 15, message: "\\");
     std\assert(~15 == -16, message: "~");
     std\assert(12 & 23 == 4, message: "&");
+}
+
+test "Bitwise" {
+    final a = 15;
+    final b = 12;
+
+    std\assert(a << 3 == 120, message: "<<");
+    std\assert(a >> 3 == 1, message: ">>");
+    std\assert(a ^ 3 == 12, message: "^");
+    std\assert(a | 3 == a, message: "\\");
+    std\assert(~a == -16, message: "~");
+    std\assert(b & 23 == 4, message: "&");
 }


### PR DESCRIPTION
There's room in the NaN boxed Values to hold more than 32 bits for an integer so we take that space. Since i48 does not exists in C ABI, FFI must still use i32.

closes #306